### PR TITLE
textlint を HTML にも対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN apt-get update && \
         textlint-rule-no-mix-dearu-desumasu \
         textlint-filter-rule-comments \
         textlint-filter-rule-allowlist \
+        textlint-plugin-html \
         textlint-plugin-latex2e && \
     apt-get clean && \
     apt-get autoremove -y && \


### PR DESCRIPTION
本来、別リポジトリ（イメージ）にするべきだが、3年演習と卒論で同一コンテナイメージを使いたいので、ここに入れた。